### PR TITLE
Add link to wiki

### DIFF
--- a/dezentrale_web/templates/base.html
+++ b/dezentrale_web/templates/base.html
@@ -25,12 +25,12 @@
         <li><a href="/">Start</a></li>
         <!-- https://dezentrale.space/dokumente -->
         <li><a href="/dokumente">Dokumente</a></li>
-        <!-- https://dezentrale.space/infrastruktur -->
-        <li><a href="/infrastruktur">Infrastruktur</a></li>
         <!-- https://dezentrale.space/impressum -->
         <li><a href="/impressum">Impressum</a></li>
         <!-- https://dezentrale.space/girokonto -->
         <li><a href="/girokonto">Konto</a></li>
+        <!-- https://dezentrale.space/wiki -->
+        <li><a href="/wiki/">Wiki</a></li>
     </ul>
     <ul class="actions vertical">
       <li><a href="#" class="button fit">Knopf</a></li>


### PR DESCRIPTION
Remove Infrastruktur page; we would like the Wiki to be the official Infrastruktur-documentation place.